### PR TITLE
fix soundness issues in unsafe usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "hoot"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "httparse",
  "log",

--- a/src/client/req.rs
+++ b/src/client/req.rs
@@ -1,6 +1,5 @@
 use core::fmt::Write;
 use core::marker::PhantomData;
-use core::mem;
 use core::ops::Deref;
 
 use crate::error::OVERFLOW;
@@ -69,8 +68,11 @@ impl<'a, S: State, V: Version, M: Method, B: BodyType> Request<'a, S, V, M, B> {
             B2::state_name(),
         );
 
-        // SAFETY: this only changes the type state of the PhantomData
-        unsafe { mem::transmute(self) }
+        Request {
+            typ: Typ(PhantomData, PhantomData, PhantomData, PhantomData),
+            state: self.state,
+            out: self.out,
+        }
     }
 
     fn header_raw(mut self, name: &str, bytes: &[u8], trailer: bool) -> Result<Self> {

--- a/src/client/res.rs
+++ b/src/client/res.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem;
 use core::str;
 
 use crate::body::{do_read_body, RecvBodyMode};
@@ -43,8 +42,10 @@ impl Response<()> {
 
 impl<S: State> Response<S> {
     fn transition<S2: State>(self) -> Response<S2> {
-        // SAFETY: this only changes the type state of the PhantomData
-        unsafe { mem::transmute(self) }
+        Response {
+            _typ: PhantomData,
+            state: self.state,
+        }
     }
 
     fn do_try_read_response<'a, 'b>(

--- a/src/header.rs
+++ b/src/header.rs
@@ -11,20 +11,18 @@ use crate::util::compare_lowercase_ascii;
 use crate::{HootError, HttpVersion};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct Header<'a> {
-    name: &'a str,
-    value: &'a [u8],
-}
+#[repr(transparent)]
+pub struct Header<'a>(InnerHeader<'a>);
 
 impl<'a> Header<'a> {
     #[inline(always)]
     pub fn name(&self) -> &str {
-        self.name
+        self.0.name
     }
 
     #[inline(always)]
     pub fn try_value(&self) -> Option<&str> {
-        str::from_utf8(self.value).ok()
+        str::from_utf8(self.0.value).ok()
     }
 
     #[inline(always)]
@@ -34,18 +32,18 @@ impl<'a> Header<'a> {
 
     #[inline(always)]
     pub fn value_raw(&self) -> &[u8] {
-        self.value
+        self.0.value
     }
 }
 
 impl<'a> fmt::Debug for Header<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_struct("Header");
-        f.field("name", &self.name);
+        f.field("name", &self.0.name);
         if let Some(value) = self.try_value() {
             f.field("value", &value);
         } else {
-            f.field("value", &self.value);
+            f.field("value", &self.0.value);
         }
         f.finish()
     }
@@ -53,7 +51,7 @@ impl<'a> fmt::Debug for Header<'a> {
 
 pub(crate) fn transmute_headers<'a, 'b>(headers: &'b [InnerHeader<'a>]) -> &'b [Header<'a>] {
     // SAFETY: Our goal is to have hoot::Header be structurally the same
-    // as httparse::Header. This is asserted by the test below.
+    // as httparse::Header. This is guarenteed by #[repr(transparent)].
     unsafe { mem::transmute(headers) }
 }
 
@@ -147,17 +145,4 @@ fn check_headers(name: &str, forbidden: &[&str], err: HootError) -> Result<()> {
     }
 
     Ok(())
-}
-#[cfg(test)]
-mod test {
-    use super::*;
-    use memoffset::offset_of;
-
-    #[test]
-    fn assert_httparse_header_transmutability() {
-        assert_eq!(mem::size_of::<Header>(), mem::size_of::<InnerHeader>());
-        assert_eq!(mem::align_of::<Header>(), mem::align_of::<InnerHeader>());
-        assert_eq!(offset_of!(Header, name), offset_of!(InnerHeader, name));
-        assert_eq!(offset_of!(Header, value), offset_of!(InnerHeader, value));
-    }
 }

--- a/src/server/req.rs
+++ b/src/server/req.rs
@@ -1,5 +1,4 @@
 use core::marker::PhantomData;
-use core::mem;
 
 use crate::body::{do_read_body, RecvBodyMode};
 use crate::error::Result;
@@ -28,8 +27,10 @@ impl Request<()> {
 
 impl<S: State> Request<S> {
     fn transition<S2: State>(self) -> Request<S2> {
-        // SAFETY: this only changes the type state of the PhantomData
-        unsafe { mem::transmute(self) }
+        Request {
+            typ: PhantomData,
+            state: self.state,
+        }
     }
 
     fn do_try_read_request<'a, 'b>(

--- a/src/server/res.rs
+++ b/src/server/res.rs
@@ -1,6 +1,5 @@
 use core::fmt::Write;
 use core::marker::PhantomData;
-use core::mem;
 use core::ops::Deref;
 
 use crate::error::{Result, OVERFLOW};
@@ -47,9 +46,10 @@ pub struct ResumeToken<S: State, M: Method, B: BodyType> {
 
 impl ResumeToken<(), (), ()> {
     pub(crate) fn new<M: Method>(state: CallState) -> ResumeToken<SEND_STATUS, M, ()> {
-        let typ: Typ<(), (), ()> = Typ::default();
-        // Safety: This only changes the type state of the Typ.
-        unsafe { mem::transmute(ResumeToken { typ, state }) }
+        ResumeToken {
+            typ: Typ(PhantomData, PhantomData, PhantomData),
+            state,
+        }
     }
 }
 
@@ -70,8 +70,11 @@ impl<'a, S: State, M: Method, B: BodyType> Response<'a, S, M, B> {
             B2::state_name(),
         );
 
-        // SAFETY: this only changes the type state of the PhantomData
-        unsafe { mem::transmute(self) }
+        Response {
+            typ: Typ(PhantomData, PhantomData, PhantomData),
+            state: self.state,
+            out: self.out,
+        }
     }
 
     fn header_raw(mut self, name: &str, bytes: &[u8], trailer: bool) -> Result<Self> {


### PR DESCRIPTION
This patch fixes some soundness issues in the unsafe usage. These issues were unlikely to be able to cause issues in practice, but could potentially cause issues if doing something weird like mixing and matching toolchains.

It manages to significantly cut down on the unsafe usage required, so it should make auditing the crate easier in the future as well.