### PR TITLE
Reduce and test stack usage

### DIFF
--- a/src/client/amended.rs
+++ b/src/client/amended.rs
@@ -5,10 +5,8 @@ use http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, Uri, Ver
 
 use crate::body::BodyWriter;
 use crate::ext::MethodExt;
-use crate::util::{compare_lowercase_ascii, ArrayVec};
+use crate::util::compare_lowercase_ascii;
 use crate::Error;
-
-use super::MAX_EXTRA_HEADERS;
 
 /// `Request` with amends.
 ///
@@ -38,22 +36,19 @@ use super::MAX_EXTRA_HEADERS;
 pub(crate) struct AmendedRequest<Body> {
     request: Request<Option<Body>>,
     uri: Option<Uri>,
-    headers: ArrayVec<(HeaderName, HeaderValue), MAX_EXTRA_HEADERS>,
-    unset: ArrayVec<HeaderName, 3>,
+    headers: Vec<(HeaderName, HeaderValue)>,
+    unset: Vec<HeaderName>,
 }
 
 impl<Body> AmendedRequest<Body> {
     pub fn new(request: Request<Body>) -> Self {
         let (parts, body) = request.into_parts();
 
-        const UNINIT_NAME: HeaderName = HeaderName::from_static("x-null");
-        const UNINIT_VALUE: HeaderValue = HeaderValue::from_static("");
-
         AmendedRequest {
             request: Request::from_parts(parts, Some(body)),
             uri: None,
-            headers: ArrayVec::from_fn(|_| (UNINIT_NAME, UNINIT_VALUE)),
-            unset: ArrayVec::from_fn(|_| UNINIT_NAME),
+            headers: vec![],
+            unset: vec![],
         }
     }
 

--- a/src/client/call.rs
+++ b/src/client/call.rs
@@ -177,7 +177,7 @@ impl<State, B> Call<State, B> {
 }
 
 #[derive(Debug, Default)]
-struct BodyState {
+pub(crate) struct BodyState {
     phase: Phase,
     writer: BodyWriter,
     reader: Option<BodyReader>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -76,7 +76,7 @@ pub fn try_parse_response<const N: usize>(
 pub fn try_parse_partial_response<const N: usize>(
     input: &[u8],
 ) -> Result<Option<Response<()>>, Error> {
-    let mut headers = [httparse::EMPTY_HEADER; N]; // 100 headers ~3kb
+    let mut headers = vec![httparse::EMPTY_HEADER; N]; // 100 headers ~3kb
 
     let mut res = httparse::Response::new(&mut headers);
 


### PR DESCRIPTION
When I wrote ureq-proto, I had `no_std` (without `alloc`) in mind. Hence I tried to cram everything on the stack. This resulted in excessively large structs of `Flow` (via `Call`). The problem is using fixed sized arrays to anticipate an unknown number of headers to be added to the call.

This PR gives up on the idea of being without `alloc`. It embraces regular `Vec` to store unknown sized collections on the heap.