### PR TITLE
feat: add extension CapitalizeHeaders

### DIFF
--- a/src/client/amended.rs
+++ b/src/client/amended.rs
@@ -6,7 +6,7 @@ use http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, Uri, Ver
 use crate::body::BodyWriter;
 use crate::ext::MethodExt;
 use crate::util::compare_lowercase_ascii;
-use crate::Error;
+use crate::{CapitalizeHeaders, Error};
 
 /// `Request` with amends.
 ///
@@ -159,6 +159,14 @@ impl<Body> AmendedRequest<Body> {
     pub fn new_uri_from_location(&self, location: &str) -> Result<Uri, Error> {
         let base = self.uri().clone();
         join(base, location)
+    }
+
+    pub fn needs_capitalization(&self) -> bool {
+        if !matches!(self.version(), Version::HTTP_09 | Version::HTTP_10 | Version::HTTP_11) {
+            return false;
+        }
+
+        self.request.extensions().get::<CapitalizeHeaders>().is_some()
     }
 
     pub fn analyze(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,3 +36,7 @@ pub mod parser;
 
 #[doc(hidden)]
 pub use util::ArrayVec;
+
+/// Capitalize the names of headers in HTTP <2.
+#[derive(Debug, Clone, Copy)]
+pub struct CapitalizeHeaders;


### PR DESCRIPTION
In some poor implementations of HTTP <2, headers are not treated in a case-insensitive manner.
Since it's not possible to preserve the case with the `http` crate, capitalizing the headers should be enough.