### PR TITLE
Make server CONNECT flow RFC compliant

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -267,9 +267,7 @@ impl BodyReader {
     ) -> Result<Self, Error> {
         use crate::ext::MethodExt;
 
-        let is_head = method == Method::HEAD;
-
-        if is_head {
+        if !method.allow_response_body() {
             return Ok(Self::NoBody);
         }
 

--- a/src/client/amended.rs
+++ b/src/client/amended.rs
@@ -55,14 +55,18 @@ impl AmendedRequest {
 
     pub fn prelude(&self) -> (&Method, &str, Version) {
         let r = &self.request;
-        (
-            r.method(),
+
+        let target = if r.method() == Method::CONNECT {
+            // unwrap allowed as previous code returns error if no authority exists for CONNECT request
+            self.uri().authority().unwrap().as_str()
+        } else {
             self.uri()
                 .path_and_query()
                 .map(|p| p.as_str())
-                .unwrap_or("/"),
-            r.version(),
-        )
+                .unwrap_or("/")
+        };
+
+        (r.method(), target, r.version())
     }
 
     pub fn set_header<K, V>(&mut self, name: K, value: V) -> Result<(), Error>

--- a/src/client/amended.rs
+++ b/src/client/amended.rs
@@ -184,7 +184,7 @@ impl AmendedRequest {
             .filter_map(|v| v.to_str().ok())
             .any(|v| compare_lowercase_ascii(v, "chunked"));
 
-        let mut req_body_header = false;
+        let req_body_header = has_chunked || content_length.is_some();
 
         // https://datatracker.ietf.org/doc/html/rfc2616#section-4.4
         // Messages MUST NOT include both a Content-Length header field and a
@@ -192,11 +192,9 @@ impl AmendedRequest {
         // identity transfer-coding, the Content-Length MUST be ignored.
         let body_mode = if has_chunked {
             // chunked "wins"
-            req_body_header = true;
             BodyWriter::new_chunked()
         } else if let Some(n) = content_length {
             // user provided content-length second
-            req_body_header = true;
             BodyWriter::new_sized(n)
         } else {
             wanted_mode

--- a/src/client/test/scenario.rs
+++ b/src/client/test/scenario.rs
@@ -72,7 +72,7 @@ impl Scenario {
         // Write the prelude and discard
         call.write(&mut vec![0; 1024]).unwrap();
 
-        if call.inner().should_send_body {
+        if call.inner().state.writer.has_body() {
             let mut call = if call.inner().await_100_continue {
                 // Go via Await100
                 let call = match call.proceed() {

--- a/src/client/test/state_await_100.rs
+++ b/src/client/test/state_await_100.rs
@@ -14,7 +14,7 @@ fn proceed_without_100_continue() {
     assert!(call.can_keep_await_100());
 
     let inner = call.inner();
-    assert!(inner.should_send_body);
+    assert!(inner.state.writer.has_body());
     assert!(inner.close_reason.is_empty());
 
     match call.proceed() {
@@ -39,7 +39,7 @@ fn proceed_after_100_continue() {
     assert!(!call.can_keep_await_100());
 
     let inner = call.inner();
-    assert!(inner.should_send_body);
+    assert!(inner.state.writer.has_body());
     assert!(inner.close_reason.is_empty());
 
     match call.proceed() {
@@ -64,7 +64,7 @@ fn proceed_after_403() {
     assert!(!call.can_keep_await_100());
 
     let inner = call.inner();
-    assert!(!inner.should_send_body);
+    assert!(!inner.state.writer.has_body());
     assert!(!inner.close_reason.is_empty());
 
     match call.proceed() {
@@ -89,7 +89,7 @@ fn proceed_after_200() {
     assert!(!call.can_keep_await_100());
 
     let inner = call.inner();
-    assert!(!inner.should_send_body);
+    assert!(!inner.state.writer.has_body());
     assert!(!inner.close_reason.is_empty());
 
     match call.proceed() {
@@ -114,7 +114,7 @@ fn proceed_after_403_with_headers() {
     assert!(!call.can_keep_await_100());
 
     let inner = call.inner();
-    assert!(!inner.should_send_body);
+    assert!(!inner.state.writer.has_body());
     assert!(!inner.close_reason.is_empty());
 
     match call.proceed() {

--- a/src/client/test/state_send_body.rs
+++ b/src/client/test/state_send_body.rs
@@ -129,7 +129,7 @@ fn send_body_despite_method() {
 
     let mut call = scenario.to_prepare();
 
-    call.send_body_despite_method();
+    call.force_send_body();
 
     let mut call = call.proceed();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum Error {
     ChunkExpectedCrLf,
     BodyContentAfterFinish,
     BodyLargerThanContentLength,
+    BodyNotAllowed,
     HttpParseFail(String),
     HttpParseTooManyHeaders,
     NoLocationHeader,
@@ -60,6 +61,9 @@ impl fmt::Display for Error {
             }
             Error::BodyLargerThanContentLength => {
                 write!(f, "attempt to write larger body than content-length")
+            }
+            Error::BodyNotAllowed => {
+                write!(f, "body not allowed by method")
             }
             Error::HttpParseFail(v) => write!(f, "http parse fail: {}", v),
             Error::HttpParseTooManyHeaders => write!(f, "http parse resulted in too many headers"),

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -28,6 +28,7 @@ pub(crate) trait MethodExt {
     #[cfg(feature = "client")]
     fn is_http11(&self) -> bool;
     fn need_request_body(&self) -> bool;
+    fn allow_response_body(&self) -> bool;
     #[cfg(feature = "client")]
     fn verify_version(&self, version: http::Version) -> Result<(), crate::Error>;
 }
@@ -50,6 +51,10 @@ impl MethodExt for Method {
 
     fn need_request_body(&self) -> bool {
         self == Method::POST || self == Method::PUT || self == Method::PATCH
+    }
+
+    fn allow_response_body(&self) -> bool {
+        self != Method::HEAD && self != Method::CONNECT
     }
 
     #[cfg(feature = "client")]

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -28,7 +28,7 @@ pub(crate) trait MethodExt {
     #[cfg(feature = "client")]
     fn is_http11(&self) -> bool;
     fn need_request_body(&self) -> bool;
-    fn allow_response_body(&self) -> bool;
+    fn allow_request_body(&self) -> bool;
     #[cfg(feature = "client")]
     fn verify_version(&self, version: http::Version) -> Result<(), crate::Error>;
 }
@@ -53,7 +53,7 @@ impl MethodExt for Method {
         self == Method::POST || self == Method::PUT || self == Method::PATCH
     }
 
-    fn allow_response_body(&self) -> bool {
+    fn allow_request_body(&self) -> bool {
         self != Method::HEAD && self != Method::CONNECT
     }
 

--- a/src/server/provres.rs
+++ b/src/server/provres.rs
@@ -1,5 +1,6 @@
 use http::{header, Response};
 
+use crate::ext::MethodExt;
 use crate::{CloseReason, Error};
 
 use super::state::{ProvideResponse, SendResponse};
@@ -33,7 +34,9 @@ impl Reply<ProvideResponse> {
         let writer = inner.state.writer.take().unwrap();
         let info = response.analyze(writer)?;
 
-        if !info.res_body_header && info.body_mode.has_body() {
+        let allow_body = inner.method.as_ref().unwrap().allow_response_body();
+
+        if !info.res_body_header && info.body_mode.has_body() && allow_body {
             // User did not set a body header, we set one.
             let header = info.body_mode.body_header();
             response.set_header(header.0, header.1)?;

--- a/src/server/provres.rs
+++ b/src/server/provres.rs
@@ -1,6 +1,6 @@
 use http::{header, Response};
 
-use crate::ext::MethodExt;
+use crate::body::response_body_allowed;
 use crate::{CloseReason, Error};
 
 use super::state::{ProvideResponse, SendResponse};
@@ -34,9 +34,23 @@ impl Reply<ProvideResponse> {
         let writer = inner.state.writer.take().unwrap();
         let info = response.analyze(writer)?;
 
-        let allow_body = inner.method.as_ref().unwrap().allow_response_body();
+        let body_provided = info.body_mode.has_body();
 
-        if !info.res_body_header && info.body_mode.has_body() && allow_body {
+        let (_, status) = response.prelude();
+        let status = status.into();
+        let method = inner.method.as_ref().unwrap();
+
+        let body_allowed = response_body_allowed(method, status, info.body_mode.body_mode());
+        let force_send = inner.force_send_body;
+
+        let should_send_body = body_allowed || force_send;
+
+        if body_provided && !should_send_body {
+            // User set a body header but method does not allow one
+            return Err(Error::BodyNotAllowed);
+        }
+
+        if body_provided && !info.res_body_header && should_send_body {
             // User did not set a body header, we set one.
             let header = info.body_mode.body_header();
             response.set_header(header.0, header.1)?;
@@ -45,5 +59,14 @@ impl Reply<ProvideResponse> {
         inner.state.writer = Some(info.body_mode);
 
         Ok(Reply::wrap(inner))
+    }
+
+    /// Convert the state to send a body despite the method
+    ///
+    /// Methods like HEAD and CONNECT should not have attached bodies.
+    /// Some broken APIs use bodies anyway and this is an escape hatch to
+    /// interoperate with such services.
+    pub fn force_send_body(&mut self) {
+        self.inner.force_send_body = true;
     }
 }

--- a/src/server/sendres.rs
+++ b/src/server/sendres.rs
@@ -47,16 +47,13 @@ impl Reply<SendResponse> {
     pub fn proceed(self) -> SendResponseResult {
         assert!(self.is_finished());
 
-        let inner = self.inner;
-
-        let method = inner.method.as_ref().unwrap();
-
-        // unwrap is ok because method is always set during request parsing
-        if inner.state.need_response_body(method) {
-            SendResponseResult::SendBody(Reply::wrap(inner))
-        } else {
-            SendResponseResult::Cleanup(Reply::wrap(inner))
+        if let Some(writer) = self.inner.state.writer {
+            if writer.has_body() {
+                return SendResponseResult::SendBody(Reply::wrap(self.inner));
+            }
         }
+
+        SendResponseResult::Cleanup(Reply::wrap(self.inner))
     }
 }
 

--- a/src/server/sendres.rs
+++ b/src/server/sendres.rs
@@ -101,11 +101,8 @@ fn try_write_prelude_part(
             let all = response.headers();
             let skipped = all.skip(*index);
 
-            if header_count > 0 {
-                do_write_headers(skipped, index, header_count - 1, w);
-            }
-
-            if *index == header_count {
+            do_write_headers(skipped, index, w);
+            if *index == header_count && w.try_write(|w| write!(w, "\r\n")) {
                 *phase = ResponsePhase::Body;
             }
             false
@@ -116,7 +113,7 @@ fn try_write_prelude_part(
     }
 }
 
-fn do_write_headers<'a, I>(headers: I, index: &mut usize, last_index: usize, w: &mut Writer)
+fn do_write_headers<'a, I>(headers: I, index: &mut usize, w: &mut Writer)
 where
     I: Iterator<Item = (&'a HeaderName, &'a HeaderValue)>,
 {
@@ -125,9 +122,7 @@ where
             write!(w, "{}: ", h.0)?;
             w.write_all(h.1.as_bytes())?;
             write!(w, "\r\n")?;
-            if *index == last_index {
-                write!(w, "\r\n")?;
-            }
+
             Ok(())
         });
 


### PR DESCRIPTION
CONNECT requests and responses should not have body headers and servers must ignore any headers they do receive.

PR enforces this behavior, skipping RecvBody and SendBody states when server receives a CONNECT request, regardless of the attached body headers. Also, prevents body headers being added to the response, when none are specified.