### PR TITLE
Skip SendBody when explict Content-Length: 0 (regression fix)

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -64,7 +64,11 @@ impl BodyWriter {
     }
 
     pub fn has_body(&self) -> bool {
-        matches!(self.mode, SenderMode::Sized(_) | SenderMode::Chunked)
+        match self.mode {
+            SenderMode::Sized(n) => n > 0,
+            SenderMode::Chunked => true,
+            SenderMode::None => false,
+        }
     }
 
     pub fn is_chunked(&self) -> bool {


### PR DESCRIPTION
When explicitly setting a content-length header of 0 on a GET request (or POST and presumably others), the "SendBody" stage doesn't get skipped. "SendBody" does get skipped if the header is left out however.

Seems to have been introduced by my PR for proper connect handling (#24). Whipped up a test-case for it. Will fix tomorrow morning at work.