### PR TITLE
Use package.exclude to remove unneeded scripts & data for deployment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "ureq support crate"
 keywords = ["http", "server", "web"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/algesten/ureq-proto"
+exclude = ["/cargo_deny.sh", "/deny.toml", "/doc/", "/run-fuzz.sh", "/test.sh"]
 
 # MSRV
 rust-version = "1.71.1"


### PR DESCRIPTION
This brings this crate in line with the `ureq` crate as well (which also uses `package.exclude`), makes the published crate slightly smaller (304.5KiB compared to 311.0KiB before uncompressed, 58.5KiB compared to 62.8KiB before compressed), and also allows easier auditing as this removes some binary data from the published crate (`/doc/client-states.monopic`).